### PR TITLE
fix: python project for uv

### DIFF
--- a/quickstart/python/.gitignore
+++ b/quickstart/python/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .venv/
+uv.lock
 

--- a/quickstart/python/pyproject.toml
+++ b/quickstart/python/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "EarlyAccessProgramScriptsPy"
+version = "0.0.1"
+description = "Learn more about python samples using the YubiKey 5.8."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "fido2"
+]
+


### PR DESCRIPTION
without it no `uv`.

Might need `rust` installed because of `cryptography` dependency.